### PR TITLE
Add support for MacOS

### DIFF
--- a/certs/Makefile
+++ b/certs/Makefile
@@ -35,7 +35,16 @@ gen-certs:
 	${CONTAINER_CMD} run --rm -v $(CERTS_DIR_LOCAL):/opt/certs:z \
 	           -e KOJI_USER="kojiadmin" \
 	           -it ${IMAGE_NAME}
+ifeq ($(shell uname -s),Linux)
+	@echo "Detected Linux OS. Running podman unshare directly."
 	${CONTAINER_CMD} unshare chmod -fR a+rw $(CERTS_DIR_LOCAL)
+else ifeq ($(shell uname -s),Darwin)
+	@echo "Detected macOS OS. Running podman unshare inside Podman machine."
+	${CONTAINER_CMD} machine ssh "${CONTAINER_CMD} unshare chmod -fR a+rw $(CERTS_DIR_LOCAL)"
+else
+	@echo "Unsupported OS: $(shell uname -s). Cannot run podman unshare."
+	@exit 1
+endif
 	mkdir -p ../hub/certs
 	rm -f ../hub/certs/*
 	ln $(CERTS_DIR_LOCAL)/root-ca/koji-ca.crt ../hub/certs/koji-ca.crt

--- a/create_dirs
+++ b/create_dirs
@@ -2,9 +2,22 @@
 
 # koji work directories
 BASEDIR=basedir
+OS_NAME=$(uname -s) # Get the operating system name
+
 mkdir $BASEDIR
 chmod 777 $BASEDIR
+
+echo "Detected OS: $OS_NAME"
+
 # own it by container's apache
-podman unshare chown 48:48 $BASEDIR
+if [ "$OS_NAME" = "Linux" ]; then
+    echo "Running podman unshare directly on Linux host..."
+    podman unshare chown 48:48 $BASEDIR
+elif [ "$OS_NAME" = "Darwin" ]; then
+    echo "Running podman unshare inside Podman machine (macOS host)..."
+    podman machine ssh "podman unshare chown 48:48 $(pwd)/$BASEDIR"
+else
+    echo "Unsupported OS for this operation: $OS_NAME"
+fi
 
 mkdir db/data


### PR DESCRIPTION
`podman unshare` commands in `create_dirs` and `certs/Makefile` fails when trying to build koji-container-dev on MacOS.
This PR checks the OS and runs `podman unshare ..` inside `podman machine ssh` if detected OS is MacOS.